### PR TITLE
2.1.0

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,7 +1,9 @@
+ignore:
+  - previous_drafts/**/*
 MD001: true # heading-increment
 MD002: true # first-heading-h1
 MD003: # heading-style
-  style: setext_with_atx
+  style: atx
 MD004: # ul-style
   style: consistent
 MD005: true # list-indent
@@ -44,7 +46,17 @@ MD031: # blanks-around-fences
   list_items: true
 MD032: true # blanks-around-lists
 MD033: # no-inline-html
-  allowed_elements: null
+  allowed_elements:
+    - a
+    - abbr
+    - br
+    - li
+    - ol
+    - table
+    - td
+    - th
+    - tr
+    - ul
 MD034: true # no-bare-urls
 MD035: # hr-style
   style: consistent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,4 @@
-Change Log: @brandonramsey/eslint-config
-==================================================================
+# Change Log: @brandonramsey/eslint-config
 
 ## [1.0.0] - 2019-05-29
 
@@ -21,8 +20,8 @@ The no-void and no-undefined rules were both set to `ERROR`, which
 caused a logical conflict.
 
 Since ES5, undefined has been immutable, so there is no longer a
-reason to use void 0 instead, other than to prevent shadowing of `undefined`
-as an argument name in a function.
+reason to use void 0 instead, other than to prevent shadowing of
+`undefined` as an argument name in a function.
 
 The `no-shadow-restricted-names` rule was already enabled and will
 prevent `undefined` from being used as an argument name in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,3 +29,9 @@ functions, so this is a non-issue.
 
 *Additionally, no-shadow-restricted-names will prevent `NaN`,
 `Infinity`, `eval`, and `arguments` from being shadowed.*
+
+### Changed
+
+- **Update markdownlint configuration**: Updated configuration settings
+    in `.markdownlint.yaml` and modified markdown files to adhere
+    to new settings.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,32 @@
-Change Log: @bramsey/eslint-config
-===========================================================================
+Change Log: @brandonramsey/eslint-config
+==================================================================
 
-[1.0.0] - 2019-08-02
----------------------------------------------------------------------------
+## [1.0.0] - 2019-05-29
 
 Initial Release
+
+## [2.0.0] - 2019-05-29
+
+### Changed
+
+- **Reduced indentation**: Reduced indentation from 4 spaces to 2
+
+## [2.1.0] - 2020-10-27
+
+### Fixed
+
+#### no-void/no-undefined rules conflict #26
+
+The no-void and no-undefined rules were both set to `ERROR`, which
+caused a logical conflict.
+
+Since ES5, undefined has been immutable, so there is no longer a
+reason to use void 0 instead, other than to prevent shadowing of `undefined`
+as an argument name in a function.
+
+The `no-shadow-restricted-names` rule was already enabled and will
+prevent `undefined` from being used as an argument name in
+functions, so this is a non-issue.
+
+*Additionally, no-shadow-restricted-names will prevent `NaN`,
+`Infinity`, `eval`, and `arguments` from being shadowed.*

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-@bramsey/eslint-config
-===========================================================================
+# @brandonramsey/eslint-config
 
 Sensible eslint config defaults for node, serverless, and react
 
@@ -19,8 +18,7 @@ To install, take the following steps:
     to your `.npmrc` file. If `.npmrc` does not exist, create it.
 2. Install package: `npm install --save-dev @brandonramsey/eslint-config`
 
-Usage
----------------------------------------------------------------------------
+## Usage
 
 Use this eslint config by specifying the desired ruleset in the *extends*
 property of your `.eslintrc` (or equivalent) configuration file.
@@ -28,8 +26,7 @@ property of your `.eslintrc` (or equivalent) configuration file.
 You can choose the `node`, `react`, or `lambda` rule set. If no
 specific ruleset is given, the `node` rule set is used.
 
-Examples
----------------------------------------------------------------------------
+## Examples
 
 ### .eslintrc Using node Rule Set
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@brandonramsey/eslint-config",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@brandonramsey/eslint-config",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "Sensible eslint config defaults for node, serverless, and react",
     "main": "index.js",
     "directories": {


### PR DESCRIPTION
## [2.1.0] - 2020-10-27

### Fixed

#### no-void/no-undefined rules conflict #26

The no-void and no-undefined rules were both set to `ERROR`, which
caused a logical conflict.

Since ES5, undefined has been immutable, so there is no longer a
reason to use void 0 instead, other than to prevent shadowing of
`undefined` as an argument name in a function.

The `no-shadow-restricted-names` rule was already enabled and will
prevent `undefined` from being used as an argument name in
functions, so this is a non-issue.

*Additionally, no-shadow-restricted-names will prevent `NaN`,
`Infinity`, `eval`, and `arguments` from being shadowed.*

### Changed

- **Update markdownlint configuration**: Updated configuration settings
    in `.markdownlint.yaml` and modified markdown files to adhere
    to new settings.
